### PR TITLE
Protest tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-os:
-  - linux
 language: nix
-before_install:
-  - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
-  - cachix use dapp
-  - git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  - nix-env -f $HOME/.dapp/dapptools -iA dapp solc
-script:
-  - dapp --use solc:0.6.7 test
+script: |
+  nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  cachix use dapp
+  git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
+  nix-env -Q -f $HOME/.dapp/dapptools -iA dapp solc
+  dapp --use solc:0.6.7 test
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ os:
   - linux
 language: nix
 before_install:
-  - nix-env --quiet -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
   - cachix use dapp
   - git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  - nix-env --quiet -f $HOME/.dapp/dapptools -iA dapp solc
+  - nix-env -f $HOME/.dapp/dapptools -iA dapp solc
 script:
   - dapp --use solc:0.6.7 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ os:
   - linux
 language: nix
 before_install:
-  - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  - nix-env --quiet -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
   - cachix use dapp
   - git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  - nix-env -f $HOME/.dapp/dapptools -iA dapp solc
+  - nix-env --quiet -f $HOME/.dapp/dapptools -iA dapp solc
 script:
   - dapp --use solc:0.6.7 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
-os:
-  - linux
 language: nix
-before_install:
-  - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
-  - cachix use dapp
-  - git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  - nix-env -f $HOME/.dapp/dapptools -iA dapp solc
-script:
-  - dapp --use solc:0.6.7 test
+script: |
+  nix-env -if --quiet https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  cachix use dapp
+  git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
+  nix-env -f --quiet $HOME/.dapp/dapptools -iA dapp solc
+  dapp --use solc:0.6.7 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: nix
 script: |
-  nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  nix-env -Q --max-silent-time 300 -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
   cachix use dapp
   git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  nix-env -Q -f $HOME/.dapp/dapptools -iA dapp solc
+  nix-env -Q --max-silent-time 300 -f $HOME/.dapp/dapptools -iA dapp solc
   dapp --use solc:0.6.7 test
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: nix
 script: |
-  nix-env -if --quiet https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= --quiet
   cachix use dapp
   git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  nix-env -f --quiet $HOME/.dapp/dapptools -iA dapp solc
+  nix-env -f $HOME/.dapp/dapptools -iA dapp solc --quiet
   dapp --use solc:0.6.7 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+os:
+  - linux
 language: nix
-script: |
-  nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
-  cachix use dapp
-  git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  nix-env -f $HOME/.dapp/dapptools -iA dapp solc
-  dapp --use solc:0.6.7 test
+before_install:
+  - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  - cachix use dapp
+  - git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
+  - nix-env -f $HOME/.dapp/dapptools -iA dapp solc
+script:
+  - dapp --use solc:0.6.7 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+os:
+  - linux
 language: nix
-script: |
-  nix-env -Q --max-silent-time 300 -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
-  cachix use dapp
-  git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  nix-env -Q --max-silent-time 300 -f $HOME/.dapp/dapptools -iA dapp solc
-  dapp --use solc:0.6.7 test
-
-
+before_install:
+  - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  - cachix use dapp
+  - git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
+  - nix-env -f $HOME/.dapp/dapptools -iA dapp solc
+script:
+  - dapp --use solc:0.6.7 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: nix
 script: |
-  nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= --quiet
+  nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
   cachix use dapp
   git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  nix-env -f $HOME/.dapp/dapptools -iA dapp solc --quiet
+  travis_wait 30 nix-env -Q -f $HOME/.dapp/dapptools -iA dapp solc
   dapp --use solc:0.6.7 test
+
+

--- a/src/test/pause.t.sol
+++ b/src/test/pause.t.sol
@@ -143,7 +143,6 @@ contract Constructor is DSTest {
         DSPause pause = new DSPause(100, address(0x0), authority);
         assertEq(address(pause.authority()), address(authority));
     }
-
 }
 
 contract Admin is Test {
@@ -228,6 +227,26 @@ contract Schedule is Test {
         pause.scheduleTransaction(usr, codeHash, parameters, eta);
     }
 
+    function testFail_schedule_above_max_scheduled_txs() public {
+        address      usr = target;
+        bytes32      codeHash = extcodehash(usr);
+        uint         eta = now + pause.delay();
+
+        for (uint i = 0; i <= pause.maxScheduledTransactions(); i++) {
+            bytes memory parameters = abi.encodeWithSignature("give(uint256)", address(i));    
+            pause.scheduleTransaction(usr, codeHash, parameters, eta);
+        }
+    }  
+
+    function testFail_schedule_eta_above_max_delay() public {
+        address      usr = target;
+        bytes32      codeHash = extcodehash(usr);
+        bytes memory parameters = abi.encodeWithSignature("get()");
+        uint         eta = now + pause.MAX_DELAY() + 1;
+
+        pause.scheduleTransaction(usr, codeHash, parameters, eta);
+    } 
+
     function test_schedule_populates_scheduled_transactions_mapping() public {
         address      usr = target;
         bytes32      codeHash = extcodehash(usr);
@@ -240,6 +259,15 @@ contract Schedule is Test {
         assertTrue(pause.scheduledTransactions(id));
     }
 
+    function testFail_schedule_duplicate_transactionP() public {
+        address      usr = target;
+        bytes32      codeHash = extcodehash(usr);
+        bytes memory parameters = abi.encodeWithSignature("get()");
+        uint         eta = now + pause.delay();
+
+        pause.scheduleTransaction(usr, codeHash, parameters, eta);
+        pause.scheduleTransaction(usr, codeHash, parameters, eta + 1);
+    } 
 }
 
 contract Execute is Test {
@@ -263,6 +291,17 @@ contract Execute is Test {
         pause.scheduleTransaction(usr, codeHash, parameters, eta);
         hevm.warp(eta);
         pause.executeTransaction(usr, codeHash, parameters, eta);
+        pause.executeTransaction(usr, codeHash, parameters, eta);
+    }
+
+    function testFail_execution_too_late() public {
+        address      usr = target;
+        bytes32      codeHash = extcodehash(usr);
+        bytes memory parameters = abi.encodeWithSignature("get()");
+        uint         eta = now + pause.delay();
+
+        pause.scheduleTransaction(usr, codeHash, parameters, eta);
+        hevm.warp(eta + pause.EXEC_TIME());
         pause.executeTransaction(usr, codeHash, parameters, eta);
     }
 
@@ -326,10 +365,9 @@ contract Execute is Test {
         bytes memory out = pause.executeTransaction(usr, codeHash, parameters, eta);
         assertEq(b32(out), bytes32("Hello"));
     }
-
 }
 
-contract AbandonTransaction is Test {
+contract Abandon is Test {
 
     function testFail_call_from_unauthorized() public {
         address      usr = target;
@@ -358,4 +396,15 @@ contract AbandonTransaction is Test {
         assertTrue(!pause.scheduledTransactions(id));
     }
 
+    function testFail_abandon_unscheduled_transaction() public {
+        address      usr = target;
+        bytes32      codeHash = extcodehash(usr);
+        bytes memory parameters = abi.encodeWithSignature("get()");
+        uint         eta = now + pause.delay();
+
+        // pause.scheduleTransaction(usr, codeHash, parameters, eta);
+        hevm.warp(eta);
+
+        pause.abandonTransaction(usr, codeHash, parameters, eta);
+    }
 }

--- a/src/test/pause.t.sol
+++ b/src/test/pause.t.sol
@@ -259,7 +259,7 @@ contract Schedule is Test {
         assertTrue(pause.scheduledTransactions(id));
     }
 
-    function testFail_schedule_duplicate_transactionP() public {
+        function testFail_schedule_duplicate_transaction() public {
         address      usr = target;
         bytes32      codeHash = extcodehash(usr);
         bytes memory parameters = abi.encodeWithSignature("get()");
@@ -267,7 +267,37 @@ contract Schedule is Test {
 
         pause.scheduleTransaction(usr, codeHash, parameters, eta);
         pause.scheduleTransaction(usr, codeHash, parameters, eta + 1);
-    } 
+    }   
+
+    function test_schedule_duplicate_transaction_after_execution() public {
+        address      usr = target;
+        bytes32      codeHash = extcodehash(usr);
+        bytes memory parameters = abi.encodeWithSignature("get()");
+        uint         eta = now + pause.delay();
+
+        pause.scheduleTransaction(usr, codeHash, parameters, eta);
+        hevm.warp(eta);
+        pause.executeTransaction(usr, codeHash, parameters, eta);
+
+        pause.scheduleTransaction(usr, codeHash, parameters, now + pause.delay());
+        bytes32 id = keccak256(abi.encode(usr, codeHash, parameters, now + pause.delay()));
+        assertTrue(pause.scheduledTransactions(id));
+    }
+
+    function test_schedule_duplicate_transaction_after_abandon() public {
+        address      usr = target;
+        bytes32      codeHash = extcodehash(usr);
+        bytes memory parameters = abi.encodeWithSignature("get()");
+        uint         eta = now + pause.delay();
+
+        pause.scheduleTransaction(usr, codeHash, parameters, eta);
+        hevm.warp(eta);
+        pause.abandonTransaction(usr, codeHash, parameters, eta);
+
+        pause.scheduleTransaction(usr, codeHash, parameters, now + pause.delay());
+        bytes32 id = keccak256(abi.encode(usr, codeHash, parameters, now + pause.delay()));
+        assertTrue(pause.scheduledTransactions(id));
+    }
 }
 
 contract Execute is Test {

--- a/src/test/protest-pause.t.sol
+++ b/src/test/protest-pause.t.sol
@@ -387,7 +387,6 @@ contract Schedule is Test {
         bytes32 id = keccak256(abi.encode(usr, codeHash, parameters, now + pause.delay()));
         assertTrue(pause.scheduledTransactions(id));
     }
-
 }
 
 contract Execute is Test {


### PR DESCRIPTION
Test:
- TransactionDelay in protest-pause is created and updated correctly
- Only the protester can protest against a transaction
- currentlyScheduledTransactions cannot go above maxScheduledTransactions (both protest and basic pause)
- The protester cannot protest against any transaction anymore if protesterLifetime was passed
- No transaction can be scheduled more than MAX_DELAY in the future (both protest and basic)
- A scheduled tx must be executed between earliestExecutionTime and earliestExecutionTime + EXEC_TIME and not after (both pause and basic)
- A scheduled tx cannot be protested against if the protestEnd threshold was passed since the time when the tx was scheduled
- protestWindowAvailable works
- timeUntilProposalProtestDeadline returns a correct result
- protestAgainstTransaction works correctly; the protester cannot protest twice against one tx
- Cannot abandon an unscheduled tx (both protest and basic)
- Cannot schedule two different txs with the exact same parameters at the same time (even if earliestExecutionTime is different); you must first abadon OR execute the first tx to execute the second one but you can still schedule txs with different parameters (either a different usr, codeHash or parameters); test for both protest and basic
getTransactionDelays correctly returns data